### PR TITLE
Fix kube-controller-manager template error when networking.podSubnet is set in values

### DIFF
--- a/deploy/helm/kubernetes/templates/controller-manager-deployment.yaml
+++ b/deploy/helm/kubernetes/templates/controller-manager-deployment.yaml
@@ -89,7 +89,7 @@ spec:
         - --tls-private-key-file=/pki/controller-manager-server/tls.key
         - --service-cluster-ip-range={{ .Values.networking.serviceSubnet }}
         {{ with .Values.networking.podSubnet }}
-        --allocate-node-cidrs=true
+        - --allocate-node-cidrs=true
         - --cluster-cidr={{ . }}
         {{- end }}
         {{- range $key, $value := .Values.controllerManager.extraArgs }}


### PR DESCRIPTION
This patch fixes template rendering error when networking.podSubnet is set.

```sh
$ helm template foo ./deploy/helm/kubernetes --set-string=networking.podSubnet=10.112.0.0/12
Error: YAML parse error on kubernetes/templates/controller-manager-deployment.yaml: error converting YAML to JSON: yaml: line 50: could not find expected ':'

Use --debug flag to render out invalid YAML
```