### PR TITLE
Use CronJob batch/v1 resource version if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Deploy Kubernetes in Kubernetes using Helm
 
 ## Requirements
 
-* Kubernetes v1.15+
+* Kubernetes v1.21+
 * Helm v3
 * cert-manager v1.0.0+
 

--- a/deploy/helm/kubernetes/templates/etcd-backup-cronjob.yaml
+++ b/deploy/helm/kubernetes/templates/etcd-backup-cronjob.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.etcd.backup.enabled }}
 {{- $fullName := include "kubernetes.fullname" . -}}
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ $fullName }}-etcd-backup

--- a/deploy/helm/kubernetes/templates/kubeadm-cronjob.yaml
+++ b/deploy/helm/kubernetes/templates/kubeadm-cronjob.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.admin.job.enabled }}
 {{- $fullName := include "kubernetes.fullname" . -}}
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: "{{ $fullName }}-kubeadm-tasks"


### PR DESCRIPTION
The batch/v2alpha1 CronJob type definitions and clients are deprecated and removed in [Kubernetes v1.21](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md#deprecation). This patch fix deprecation warnings related to version change.

Kubernetes v1.20.7 output:
```sh
$ kubectl version | grep Server
Server Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.7", GitCommit:"132a687512d7fb058d0f5890f07d4121b3f0a2e2", GitTreeState:"clean", BuildDate:"2021-05-27T23:27:49Z", GoVersion:"go1.15.12", Compiler:"gc", Platform:"linux/amd64"}

$ helm install foo deploy/helm/kubernetes --dry-run | grep -B1 CronJob
apiVersion: batch/v1beta1
kind: CronJob
```

Kubernetes v1.21.1 output:
```sh
$ kubectl version | grep Server
Server Version: version.Info{Major:"1", Minor:"21", GitVersion:"v1.21.1", GitCommit:"5e58841cce77d4bc13713ad2b91fa0d961e69192", GitTreeState:"clean", BuildDate:"2021-05-21T23:01:33Z", GoVersion:"go1.16.4", Compiler:"gc", Platform:"linux/amd64"}

$ helm install foo deploy/helm/kubernetes --dry-run | grep -B1 CronJob
apiVersion: batch/v1
kind: CronJob
```
