### PR TITLE
Konnectivity daemonset

### DIFF
--- a/deploy/helm/kubernetes/manifests/konnectivity-agent-deployment.yaml
+++ b/deploy/helm/kubernetes/manifests/konnectivity-agent-deployment.yaml
@@ -1,5 +1,13 @@
 {{- $fullName := include "kubernetes.fullname" . -}}
-{{- define "konnectivity-agent.metadata" }}
+
+{{- if .Values.konnectivityAgent.daemonSet -}}
+apiVersion: apps/v1
+kind: DaemonSet
+{{- else -}}
+apiVersion: apps/v1
+kind: Deployment
+{{- end }}
+metadata:
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
     k8s-app: konnectivity-agent
@@ -12,9 +20,14 @@
     {{- end }}
   namespace: kube-system
   name: konnectivity-agent
-{{- end -}}
-{{- define "konnectivity-agent.template" }}
-  {{- $fullName := include "kubernetes.fullname" . -}}
+spec:
+  {{- if not .Values.konnectivityAgent.daemonSet }}
+  replicas: {{ .Values.konnectivityAgent.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      k8s-app: konnectivity-agent
+  template:
     metadata:
       labels:
         k8s-app: konnectivity-agent
@@ -138,26 +151,3 @@
       {{- with .Values.konnectivityAgent.extraVolumes }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
-{{- end -}}
-{{- if false -}}
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  {{- include "konnectivity-agent.metadata" . }}
-spec:
-  replicas: {{ .Values.konnectivityAgent.replicaCount }}
-  selector:
-    matchLabels:
-      k8s-app: konnectivity-agent
-{{- else -}}
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  {{- include "konnectivity-agent.metadata" . }}
-spec:
-  selector:
-    matchLabels:
-      k8s-app: konnectivity-agent
-{{- end }}
-  template:
-    {{ include "konnectivity-agent.template" . }}

--- a/deploy/helm/kubernetes/manifests/konnectivity-agent-deployment.yaml
+++ b/deploy/helm/kubernetes/manifests/konnectivity-agent-deployment.yaml
@@ -1,7 +1,5 @@
 {{- $fullName := include "kubernetes.fullname" . -}}
-apiVersion: apps/v1
-kind: Deployment
-metadata:
+{{- define "konnectivity-agent.metadata" }}
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
     k8s-app: konnectivity-agent
@@ -14,12 +12,9 @@ metadata:
     {{- end }}
   namespace: kube-system
   name: konnectivity-agent
-spec:
-  replicas: {{ .Values.konnectivityAgent.replicaCount }}
-  selector:
-    matchLabels:
-      k8s-app: konnectivity-agent
-  template:
+{{- end -}}
+{{- define "konnectivity-agent.template" }}
+  {{- $fullName := include "kubernetes.fullname" . -}}
     metadata:
       labels:
         k8s-app: konnectivity-agent
@@ -143,3 +138,26 @@ spec:
       {{- with .Values.konnectivityAgent.extraVolumes }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
+{{- end -}}
+{{- if false -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  {{- include "konnectivity-agent.metadata" . }}
+spec:
+  replicas: {{ .Values.konnectivityAgent.replicaCount }}
+  selector:
+    matchLabels:
+      k8s-app: konnectivity-agent
+{{- else -}}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  {{- include "konnectivity-agent.metadata" . }}
+spec:
+  selector:
+    matchLabels:
+      k8s-app: konnectivity-agent
+{{- end }}
+  template:
+    {{ include "konnectivity-agent.template" . }}

--- a/deploy/helm/kubernetes/values.yaml
+++ b/deploy/helm/kubernetes/values.yaml
@@ -350,6 +350,7 @@ konnectivityAgent:
     tag: v0.0.24
     pullPolicy: IfNotPresent
     pullSecrets: []
+  daemonSet: false
   replicaCount: 2
   hostNetwork: true
 


### PR DESCRIPTION
Allows running konnectivity agents in as daemonset. Enable using:

```
Values.konnectivityAgent.daemonSet: true
```

defaults to false - use deployment.

resolves #15 