### PR TITLE
Konnectivity daemonset (2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Deploy Kubernetes in Kubernetes using Helm
 
 ```bash
 helm repo add kvaps https://kvaps.github.io/charts
-helm install foo kvaps/kubernetes --version 0.13.4 \
+helm install foo kvaps/kubernetes --version 0.13.5 \
   --namespace foo \
   --create-namespace \
   --set persistence.storageClassName=local-path

--- a/deploy/helm/kubernetes/Chart.yaml
+++ b/deploy/helm/kubernetes/Chart.yaml
@@ -1,6 +1,6 @@
 name: kubernetes
 description: Production-Grade Container Scheduling and Management
-version: 0.13.4
+version: 0.13.5
 appVersion: 1.22.4
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/3/39/Kubernetes_logo_without_workmark.svg/723px-Kubernetes_logo_without_workmark.svg.png
 keywords:

--- a/deploy/helm/kubernetes/manifests/konnectivity-agent-deployment.yaml
+++ b/deploy/helm/kubernetes/manifests/konnectivity-agent-deployment.yaml
@@ -1,6 +1,12 @@
 {{- $fullName := include "kubernetes.fullname" . -}}
+
+{{- if .Values.konnectivityAgent.daemonSet -}}
+apiVersion: apps/v1
+kind: DaemonSet
+{{- else -}}
 apiVersion: apps/v1
 kind: Deployment
+{{- end }}
 metadata:
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
@@ -15,7 +21,9 @@ metadata:
   namespace: kube-system
   name: konnectivity-agent
 spec:
+  {{- if not .Values.konnectivityAgent.daemonSet }}
   replicas: {{ .Values.konnectivityAgent.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       k8s-app: konnectivity-agent

--- a/deploy/helm/kubernetes/values.yaml
+++ b/deploy/helm/kubernetes/values.yaml
@@ -237,7 +237,7 @@ admin:
   enabled: true
   image:
     repository: ghcr.io/kvaps/kubernetes-tools
-    tag: v0.13.4
+    tag: v0.13.5
     pullPolicy: IfNotPresent
     pullSecrets: []
   replicaCount: 1

--- a/deploy/helm/kubernetes/values.yaml
+++ b/deploy/helm/kubernetes/values.yaml
@@ -350,6 +350,7 @@ konnectivityAgent:
     tag: v0.0.24
     pullPolicy: IfNotPresent
     pullSecrets: []
+  daemonSet: false
   replicaCount: 2
   hostNetwork: true
 


### PR DESCRIPTION
Allows running konnectivity agents in as daemonset. Enable using:

```
Values.konnectivityAgent.daemonSet: true
```

defaults to false - use deployment.

resolves #15 